### PR TITLE
FIX Handle missing tables in postgres on flush

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -109,7 +109,7 @@ class Controller extends BaseController implements Flushable
                 Versioned::set_stage($stage);
             }
         }
-        
+
         // Check for a possible CORS preflight request and handle if necessary
         // Refer issue 66:  https://github.com/silverstripe/silverstripe-graphql/issues/66
         if ($request->httpMethod() === 'OPTIONS') {
@@ -524,13 +524,9 @@ class Controller extends BaseController implements Flushable
                     }
                 } catch (DatabaseException $e) {
                     // Allow failures on table doesn't exist or no database selected as we're flushing in first DB build
-                    $messageByLine = explode(PHP_EOL, $e->getMessage());
-
-                    // Get the last line
-                    $last = array_pop($messageByLine);
-
-                    if (strpos($last, 'No database selected') === false
-                        && !preg_match('/\s*(table|relation) .* does(n\'t| not) exist/i', $last)
+                    $message = $e->getMessage();
+                    if (strpos($message, 'No database selected') === false
+                        && !preg_match('/\s*(table|relation) .* does(n\'t| not) exist/i', $message)
                     ) {
                         throw $e;
                     }


### PR DESCRIPTION
CI run for https://github.com/silverstripe/silverstripe-graphql/pull/483

Failure for php 8.1 mysql8.0 is the same as on the current PR to put ci.yml into graphql 3.8 - https://github.com/creative-commoners/silverstripe-graphql/runs/7210777804?check_suite_focus=true